### PR TITLE
cursor() insted stream()

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = function(schema, options) {
         stream.write(this.model.csv_header());
 
         // write data
-        return this.stream()
+        return this.cursor()
             .pipe(mapstream(function(data, cb) {
                 cb(null, data.toCSV());
             }))


### PR DESCRIPTION
Mongoose:Query.prototype.stream() is deprecated in mongoose >= 4.5.0, use Query.prototype.cursor() instead