### PR TITLE
revert: 8a2148a

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,9 +13,6 @@ try {
     mongoose = prequire('mongoose');
 }
 
-// supress mongoose promise warning
-mongoose.Promise = global.Promise;
-
 module.exports = function(schema, options) {
 
     // discover properties for use with headers / serializing


### PR DESCRIPTION
Setting `mongoose.Promise` is not part of a plugin module.

If someone not using global es6 Promise, it breaks all the promise handling outside of the mongoose query execution.
